### PR TITLE
Use the capistrano git plugin to avoid a deprecation warning

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -3,6 +3,8 @@ require 'capistrano/setup'
 
 # Includes default deployment tasks
 require 'capistrano/deploy'
+require "capistrano/scm/git"
+install_plugin Capistrano::SCM::Git
 
 # Includes tasks from other gems included in your Gemfile
 #

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,7 +188,7 @@ GEM
       nokogiri (>= 1.4.2)
       solrizer (~> 3.3)
     parallel (1.12.1)
-    parser (2.5.0.4)
+    parser (2.5.1.0)
       ast (~> 2.4.0)
     powerpack (0.1.1)
     pry (0.10.4)


### PR DESCRIPTION
Also updated parser because 2.5.0.4  was yanked and the previous wouldn't bundle install.