### PR TITLE
Remove outdated ruby version from test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
 rvm:
-  - 2.3.7 # deployed
-  - 2.5.3
+  - 2.5.3 # deployed
 sudo: false


### PR DESCRIPTION
2.5.3 is what's deployed